### PR TITLE
Player URI now defaults to the current URI

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -51,6 +51,9 @@
             let janusServerUri = document.getElementById("janusServerUri");
             let channelId = document.getElementById("channelId");
 
+            // Default to the same endpoint
+            janusServerUri.value = `${window.location.protocol}//${window.location.host}:8088/janus`;
+
             form.addEventListener("submit", (e) => {
                 e.preventDefault();
 


### PR DESCRIPTION
I was tired of manually typing in my server's URI - this change sets it to whatever URI your browser is currently navigated to.