### PR TITLE
⌨ Generate d.ts TypeScript types for distribution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 dist/*.js
+dist/*.d.ts
 node_modules/

--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
   "name": "janus-ftl-player",
-  "version": "0.0.3-alpha",
+  "version": "0.0.4-alpha",
   "description": "Simple player for Janus FTL streams",
   "main": "dist/main.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "webpack serve --mode development --open",

--- a/src/FtlPlayer.ts
+++ b/src/FtlPlayer.ts
@@ -15,7 +15,7 @@ export class FtlPlayer {
     private janusPluginHandle: (PluginHandle | null) = null;
     private options: Options;
 
-    constructor(element: HTMLVideoElement, serverUri: (string | null) = null, options: Options) {
+    constructor(element: HTMLVideoElement, serverUri: (string | null) = null, options: Options = { }) {
         // Allow configuring additional options
         this.options = {
             debug: true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,11 +10,11 @@
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
-    // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    "declaration": true,                      /* Generates corresponding '.d.ts' file. */
     // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
     // "sourceMap": true,                     /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
-    // "outDir": "./",                        /* Redirect output structure to the directory. */
+    "outDir": "./dist",                       /* Redirect output structure to the directory. */
     // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
     // "composite": true,                     /* Enable project compilation */
     // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */


### PR DESCRIPTION
Generate `d.ts` files along with our JS so that consumers have type information to work with.