### PR TITLE
Provide a hook for slow link to help inform users of packet loss

### DIFF
--- a/src/Janus.d.ts
+++ b/src/Janus.d.ts
@@ -15,7 +15,7 @@ declare module "janus-gateway" {
 		Error = 'error'
 	}
 
-	interface JSEP {}
+	interface JSEP { }
 
 	interface InitOptions {
 		debug?: boolean | 'all' | DebugLevel[];
@@ -65,7 +65,7 @@ declare module "janus-gateway" {
 		webrtcState?: (isConnected: boolean) => void;
 		iceState?: (state: 'connected' | 'failed') => void;
 		mediaState?: (state: { type: 'audio' | 'video'; on: boolean }) => void;
-		slowLink?: (state: { uplink: boolean }) => void;
+		slowLink?: (uplink: boolean, lost: number) => void;
 		onmessage?: (message: Message, jsep?: JSEP) => void;
 		onlocalstream?: (stream: MediaStream) => void;
 		onremotestream?: (stream: MediaStream) => void;


### PR DESCRIPTION
This should allow us on glimesh.tv to watch for these events, and show a message to streamers / viewers so they understand a bit better about why the video is not playing smoothly.