### PR TITLE
Switch to a Glimesh janus-gateway mirror

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,14 @@
 {
   "name": "janus-ftl-player",
-  "version": "0.0.3-alpha",
+  "version": "0.0.6-alpha",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.0.3-alpha",
+      "version": "0.0.6-alpha",
       "license": "MIT",
       "dependencies": {
-        "janus-gateway": "meetecho/janus-gateway"
+        "janus-gateway-mirror": "^0.7.5"
       },
       "devDependencies": {
         "@webpack-cli/serve": "^1.2.1",
@@ -3222,10 +3222,25 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/janus-gateway": {
-      "resolved": "git+ssh://git@github.com/meetecho/janus-gateway.git#d1d044ce781272715ef621abe9f7ac2f658842e6",
+    "node_modules/janus-gateway-mirror": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/janus-gateway-mirror/-/janus-gateway-mirror-0.7.5.tgz",
+      "integrity": "sha512-pNeuwPo1V3cPVYqWjMZ5Mlq3M+ifXGY7cksJELQLPK60a6a8oxXzEDSKHipdokG9xWs1dkAcmTnoNAO32+swUQ==",
       "dependencies": {
-        "webrtc-adapter": "6.4.0"
+        "webrtc-adapter": "7.4.0"
+      }
+    },
+    "node_modules/janus-gateway-mirror/node_modules/webrtc-adapter": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-7.4.0.tgz",
+      "integrity": "sha512-YeflMTsqnQ6/7satrJzjzN9RjpkDDsEdoRuEkIhk+oOmWgDL1ocdWhZ1lPdB21ZXXY/AmEih4cHgKoW3SYw20A==",
+      "dependencies": {
+        "rtcpeerconnection-shim": "^1.2.15",
+        "sdp": "^2.12.0"
+      },
+      "engines": {
+        "node": ">=6.0.0",
+        "npm": ">=3.10.0"
       }
     },
     "node_modules/json-parse-better-errors": {
@@ -5903,10 +5918,8 @@
       "integrity": "sha512-aWAgTW4MoSJzZPAicljkO1hsi1oKj/RRq/OJQh2PKI2UKL04c2Bs+MBOB+BBABHTXJpf9mCwHN7ANCvYsvY2sg==",
       "dev": true,
       "dependencies": {
-        "chokidar": "^3.4.1",
         "graceful-fs": "^4.1.2",
-        "neo-async": "^2.5.0",
-        "watchpack-chokidar2": "^2.0.0"
+        "neo-async": "^2.5.0"
       },
       "optionalDependencies": {
         "chokidar": "^3.4.1",
@@ -6511,7 +6524,6 @@
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
         "braces": "^2.3.2",
-        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
         "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",
@@ -6664,19 +6676,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/webrtc-adapter": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-6.4.0.tgz",
-      "integrity": "sha512-VUX/YMIRWwJy74Q2K2KBTh2VlvD4GgxLzLtGC+mecdeTjb+nxzhlCpxwx0lqpiU2apKXHqKLfxMWcrxYnmd6LA==",
-      "dependencies": {
-        "rtcpeerconnection-shim": "^1.2.14",
-        "sdp": "^2.9.0"
-      },
-      "engines": {
-        "node": ">=6.0.0",
-        "npm": ">=3.10.0"
       }
     },
     "node_modules/websocket-driver": {
@@ -9521,11 +9520,23 @@
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
     },
-    "janus-gateway": {
-      "version": "git+ssh://git@github.com/meetecho/janus-gateway.git#d1d044ce781272715ef621abe9f7ac2f658842e6",
-      "from": "janus-gateway@meetecho/janus-gateway",
+    "janus-gateway-mirror": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/janus-gateway-mirror/-/janus-gateway-mirror-0.7.5.tgz",
+      "integrity": "sha512-pNeuwPo1V3cPVYqWjMZ5Mlq3M+ifXGY7cksJELQLPK60a6a8oxXzEDSKHipdokG9xWs1dkAcmTnoNAO32+swUQ==",
       "requires": {
-        "webrtc-adapter": "6.4.0"
+        "webrtc-adapter": "7.4.0"
+      },
+      "dependencies": {
+        "webrtc-adapter": {
+          "version": "7.4.0",
+          "resolved": "https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-7.4.0.tgz",
+          "integrity": "sha512-YeflMTsqnQ6/7satrJzjzN9RjpkDDsEdoRuEkIhk+oOmWgDL1ocdWhZ1lPdB21ZXXY/AmEih4cHgKoW3SYw20A==",
+          "requires": {
+            "rtcpeerconnection-shim": "^1.2.15",
+            "sdp": "^2.12.0"
+          }
+        }
       }
     },
     "json-parse-better-errors": {
@@ -12336,15 +12347,6 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         }
-      }
-    },
-    "webrtc-adapter": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-6.4.0.tgz",
-      "integrity": "sha512-VUX/YMIRWwJy74Q2K2KBTh2VlvD4GgxLzLtGC+mecdeTjb+nxzhlCpxwx0lqpiU2apKXHqKLfxMWcrxYnmd6LA==",
-      "requires": {
-        "rtcpeerconnection-shim": "^1.2.14",
-        "sdp": "^2.9.0"
       }
     },
     "websocket-driver": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "janus-ftl-player",
-  "version": "0.0.7-alpha",
+  "version": "0.0.8-alpha",
   "description": "Simple player for Janus FTL streams",
   "main": "dist/main.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
     "webpack-dev-server": "^3.11.2"
   },
   "dependencies": {
-    "janus-gateway": "meetecho/janus-gateway"
+    "janus-gateway-mirror": "^0.7.5"
   }
 }

--- a/src/FtlPlayer.ts
+++ b/src/FtlPlayer.ts
@@ -1,4 +1,4 @@
-import { Janus, PluginHandle, Message, JSEP } from "janus-gateway";
+import { Janus, PluginHandle, Message, JSEP } from "janus-gateway-mirror";
 
 type Options = {
     debug?: boolean,

--- a/src/Janus.d.ts
+++ b/src/Janus.d.ts
@@ -83,14 +83,14 @@ declare module "janus-gateway-mirror" {
 			videoRecv?: boolean;
 			audio?: boolean | { deviceId: string };
 			video?:
-			| boolean
-			| { deviceId: string }
-			| 'lowres'
-			| 'lowres-16:9'
-			| 'stdres'
-			| 'stdres-16:9'
-			| 'hires'
-			| 'hires-16:9';
+				| boolean
+				| { deviceId: string }
+				| 'lowres'
+				| 'lowres-16:9'
+				| 'stdres'
+				| 'stdres-16:9'
+				| 'hires'
+				| 'hires-16:9';
 			data?: boolean;
 			failIfNoAudio?: boolean;
 			failIfNoVideo?: boolean;

--- a/src/Janus.d.ts
+++ b/src/Janus.d.ts
@@ -1,4 +1,4 @@
-declare module "janus-gateway" {
+declare module "janus-gateway-mirror" {
 	interface Dependencies {
 		adapter: any;
 		newWebSocket: (server: string, protocol: string) => WebSocket;
@@ -83,14 +83,14 @@ declare module "janus-gateway" {
 			videoRecv?: boolean;
 			audio?: boolean | { deviceId: string };
 			video?:
-				| boolean
-				| { deviceId: string }
-				| 'lowres'
-				| 'lowres-16:9'
-				| 'stdres'
-				| 'stdres-16:9'
-				| 'hires'
-				| 'hires-16:9';
+			| boolean
+			| { deviceId: string }
+			| 'lowres'
+			| 'lowres-16:9'
+			| 'stdres'
+			| 'stdres-16:9'
+			| 'hires'
+			| 'hires-16:9';
 			data?: boolean;
 			failIfNoAudio?: boolean;
 			failIfNoVideo?: boolean;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,7 +8,7 @@ module.exports = {
         // instead it expects a global object called 'adapter' for that.
         // Let's make that object available.
         new webpack.ProvidePlugin({
-            adapter: 'webrtc-adapter'
+            adapter: ['webrtc-adapter', 'default']
         })
     ],
     module: {
@@ -17,7 +17,7 @@ module.exports = {
             // it creates a global variable called 'Janus' and expects consumers to use it.
             // Let's use 'exports-loader' to simulate it uses 'export'.
             {
-                test: require.resolve('janus-gateway'),
+                test: require.resolve('janus-gateway-mirror'),
                 loader: 'exports-loader',
                 options: {
                     exports: 'Janus',


### PR DESCRIPTION
The mirror is intended to reduce the checkout time and size required for any usage of this repo. With these changes the checkout of the glimesh.tv repo can now happen purely unauthenticated.

The other side of this PR is the new repo @ https://github.com/Glimesh/janus-gateway-mirror which does not maintain any state, and instead will mirror whatever janus-gateway code we need to publish to npm at https://www.npmjs.com/package/janus-gateway-mirror